### PR TITLE
closes #1 - pointer events removed

### DIFF
--- a/standalone/imagezoom.css
+++ b/standalone/imagezoom.css
@@ -11,7 +11,6 @@
   -ms-transition: opacity 300ms;
   -o-transition: opacity 300ms;
   z-index: 500;
-  pointer-events: none;
   opacity: 0;
 }
 


### PR DESCRIPTION
`pointer-events: none` allows users to click the invisible content behind the overlay. Not preferred default usage imho.
